### PR TITLE
Update parse-testssl-csv.sh

### DIFF
--- a/parse-testssl-csv.sh
+++ b/parse-testssl-csv.sh
@@ -14,6 +14,6 @@ do
         mkdir SSLParse.log
     else
         of=${line//\"/}
-        grep $SEVERITY $1 | grep $line | cut -d "," -f 2,3 | cut -d "/" -f 2 | sed 's/"//g;s/,/:/g' | sort -u > SSLParse.log/$of
+        grep $SEVERITY $1 | grep $line | cut -d "," -f 2,3 | cut -d "/" -f 2 | sed 's/"//g;s/,/:/g' | sort -u >> SSLParse.log/$of
     fi
 done < <(cat $1 | grep $SEVERITY | cut -d "," -f 1 | sort -u)


### PR DESCRIPTION
Changed output from `>` to `>>` for when handling multiple files via a bash loop.

Previously would overwrite the existing file when iterating to the next .CSV to parse.